### PR TITLE
Tweaking tooling and breaking up components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["react"]
-}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React from 'react'
 import { render } from 'react-dom'
 import { Router, Route, hashHistory } from 'react-router'

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
+    "babel-polyfill": "^6.5.0",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-router": "^2.0.0"
@@ -11,6 +12,7 @@
   "devDependencies": {
     "babel-core": "^6.5.1",
     "babel-loader": "^6.2.2",
+    "babel-plugin-react-require": "^2.1.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "http-server": "^0.8.5",

--- a/src/app.js
+++ b/src/app.js
@@ -1,28 +1,12 @@
 'use strict';
 
-import React from 'react'
+import { Component } from 'react'
+import CompactMeal from './compact-meal';
 
-class CompactMeal extends React.Component {
-  render() {
-    return (
-      <div>
-        <div>{this.props.meal.name}</div>
-        <div className="compact-meal-nutrients">
-          <ul>
-            {this.props.meal.nutrients.map(nutrient => {
-              return <li key={nutrient.name}>{nutrient.name} - {nutrient.value}</li>
-            })}
-          </ul>
-        </div>
-      </div>
-    );
-  }
-};
-
-var MealApp = React.createClass({
-
-  getInitialState: function() {
-    return {
+export default class MealApp extends Component {
+  constructor(props, context) {
+    super(props, context);
+    this.state = {
       compactMeals: [{
         name: 'Edameme Spaghetti with Turkey Meatballs',
         nutrients: [{
@@ -37,9 +21,9 @@ var MealApp = React.createClass({
         {name: 'Salmon with Brccoli', nutrients: []},
       ],
     };
-  },
+  }
 
-  render: function() {
+  render() {
     return (
       <div>
         <h1>Meals</h1>
@@ -50,7 +34,5 @@ var MealApp = React.createClass({
         </ul>
       </div>
     )
-  },
-});
-
-export default MealApp;
+  }
+}

--- a/src/compact-meal.js
+++ b/src/compact-meal.js
@@ -1,0 +1,14 @@
+export default function CompactMeal(props) {
+  return (
+    <div>
+      <div>{props.meal.name}</div>
+      <div className="compact-meal-nutrients">
+        <ul>
+          {props.meal.nutrients.map(nutrient => {
+            return <li key={nutrient.name}>{nutrient.name} - {nutrient.value}</li>
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,18 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?presets[]=react&presets[]=es2015' }
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        // Anything that can be in .babelrc can be in query.
+        // https://babeljs.io/docs/usage/options/
+        query: {
+          babelrc: false,
+          presets: ['react', 'es2015'],
+          plugins: ['react-require']
+        }
+      }
     ]
   }
 }


### PR DESCRIPTION
- babel config is not in webpack loader query prop
- jsx is compiled using react when detected. No longer need explicit import React from 'react' in every component's file
- Demonstrating component as a function as these are most common components
- Initializing state the ES2015 way
